### PR TITLE
Make bower-able

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ script:
 - npm run build
 - npm run test:lint
 - wct --skip-plugin local
-- 'if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version && export TRAVIS_TAG=$(frauci-get-version) && npm run build && npm run publish-release; fi'
+- ./update.sh
 env:
   global:
-  - REPO_NAME=d2l-fetch-simple-cache
   # SAUCE_USERNAME
   - secure: tulJfszKW5CVmDqaAdDdVQfNV9+OO8dsVB2b4X5dzTwC7bF2oNREVTHSkLUbxDCzBLRCmZfCTZc+h+Hz1e5OuppBJL99rp96NRe94XgFcq8ecOYhlhxIk8yrJ2RoeRgdpAMsi0EddsuDP36i2F2x6t5kqUATk3uZwVskzlU4NIXf8LzW3XvpEzSiLfuSqrmJ4P4lAmwTxMZ+S33gBoO7me1BBL3JhaX5hHAEyawWMffyPomLwiJEe3n0M8lahN1fp8gAR3WkC2LRX8ab/omuvqgTTDzpT8buxPuqTIxypPYhXDjlM3mGWvUpZ1jcMZloyEJXRFVWmBZeYZXMgyvYhV47FpU42kXl0RP9C+v7pACrzEenWKzhsqNbkC8YbedHTAYfonJdfs5y7pzIRK8+Yxo/BUH7sxuGBOm+KEOQtlj42NI1U0llaiagm5KZHJdM4W691Y+tuZ6OU/YxBd+/ofKsuaW2lJZXkZnwnwKLHA5FsEk/Zrvi0dl2Ld+bwFpupb0D7k5Pj7SBi86igN0Zcl8VmHI6mUgZGk6bVblqd44MdySKcmCqJKz7rtC+axLlOnHj/JUAjWJWEnmXKTBygamYqrKn+0OL2VX5KtR3ateUJGrUy9BP6SehlI5Cy1R2+1Fg5tbFbH7tnz1jPdSrAabMDSGWWSZrAcoE7wXUoZ0=
   # CDN_SECRET

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ Reference the script in your html after your reference to `d2l-fetch` (see [here
 <script src="../dist/d2lfetch-simple-cache.js"></script>
 ```
 
-This will add the `simple-cache` middleware function to the `d2lfetch` object.
+This will add the `simple-cache` middleware function to the `d2lfetch` object. Alternatively, you can install `d2l-fetch-simple-cache` via bower:
+
+```sh
+bower install Brightspace/d2l-fetch-simple-cache
+```
+
+and reference it as you would any other bower package:
+
+```html
+<link rel="import" href="../d2l-fetch-simple-cache/d2l-fetch-simple-cache.html">
+```
 
 ### Simple-cache
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "d2l-fetch-simple-cache",
   "description": "Provides a middleware function for de-duplicating fetch requests for the same url+auth combination",
-  "main": "index.js",
+  "main": "d2l-fetch-simple-cache.html",
   "authors": [
     "D2L Corporation"
   ],

--- a/d2l-fetch-simple-cache.html
+++ b/d2l-fetch-simple-cache.html
@@ -1,0 +1,2 @@
+<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-simple-cache IS RELEASED -->
+<script src="https://s.brightspace.com/lib/d2lfetch-simple-cache/0.4.0/d2lfetch-simple-cache.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "d2l-fetch-simple-cache",
-  "version": "0.4.0",
   "description": "Provides a middleware function for caching fetch responses for the same url+auth combination",
   "main": "index.js",
   "author": "D2L Corporation",
@@ -38,7 +37,6 @@
     "eslint": "^3.19.0",
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^2.0.1",
-    "frau-ci": "^1.33.0",
     "frau-publisher": "^2.6.2",
     "peanut-gallery": "^1.2.0",
     "web-component-tester": "^6.0.0",

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+if ! [ "$TRAVIS_BRANCH" == "master" ] || ! [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+	echo "Version is only bumped on master"
+	exit 0
+fi
+
+lastVersion=$(git describe --abbrev=0)
+versionRegex='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
+if ! [[ $lastVersion =~ $versionRegex ]]; then
+	echo $lastVersion "is not a valid semver string"
+	exit 1
+fi
+
+majorVersion=${BASH_REMATCH[1]}
+minorVersion=${BASH_REMATCH[2]}
+patchVersion=${BASH_REMATCH[3]}
+
+lastLogMessage=$(git log -1 --pretty=format:%s%b)
+lastLogMessageShort=$(git log -1 --pretty=format:%s)
+
+majorRegex='\[increment major\]'
+patchRegex='\[increment patch\]'
+if [[ $lastLogMessage =~ $majorRegex ]]; then
+	majorVersion=$((majorVersion + 1))
+elif [[ $lastLogMessage =~ $patchRegex ]]; then
+	patchVersion=$((patchVersion + 1))
+else
+	minorVersion=$((minorVersion + 1))
+fi
+
+newVersion="${majorVersion}.${minorVersion}.${patchVersion}"
+
+# Add the upstream using GITHUB_RELEASE_TOKEN
+git remote add upstream "https://${GITHUB_RELEASE_TOKEN}@github.com/Brightspace/d2l-fetch-simple-cache.git"
+
+# Pull the merge commit
+git pull upstream master
+git checkout upstream/master
+
+# Set config so this commit shows up as coming from Travis
+git config --global user.email "travis@travis-ci.com"
+git config --global user.name "Travis CI"
+
+echo "Updating from ${lastVersion} to ${newVersion}"
+echo "<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-simple-cache IS RELEASED -->" > d2l-fetch-simple-cache.html
+echo "<script src=\"https://s.brightspace.com/lib/d2lfetch-simple-cache/"$newVersion"/d2lfetch-simple-cache.js\"></script>" >> d2l-fetch-simple-cache.html
+
+# Add the updated d2l-fetch-simple-cache.html, and add a new tag to create the release
+git add .
+git commit -m "[skip ci] Update to ${newVersion}"
+git tag -a ${newVersion} -m "${newVersion} - ${lastLogMessageShort}"
+
+git status
+
+git push upstream HEAD:master --tags
+
+# Publish the release via frau-publisher
+export TRAVIS_TAG=$newVersion
+npm run publish-release


### PR DESCRIPTION
Adding this file allows us to use bower to control the versioning of this package, rather than using the CDNified versions and hoping that they won't conflict. This file is automatically updated by Travis to point at the CDN-ified script that will be generated by frau-ci in the next step. Since the new version isn't released until _after_ this commit is pushed, it does theoretically mean that if somebody pulled master at just the right moment, d2l-fetch-simple-cache.html would be pointing to a non-existant file, but oh well. (If the consumer is using a proper bower version, this situation can't occur since the new version is only generated after the new file is CDN-ified.)